### PR TITLE
chore: support clang 11 from 2026.06.05-5a535621 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
             command: clang-tidy --version
           - plugin: clang-apply-replacements
             command: clang-apply-replacements --version
-        version: ["12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22"]
+        version: ["11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22"]
         exclude:
           # clang-apply-replacements-12_linux-amd64 is missing from upstream static-binaries
           - os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This plugin uses the pre-compiled binaries from the very handy [cpp-linter/clang
 
 ## Supported Versions
 
-Clang versions **12** through **22** are supported.
+Clang versions **11** through **22** are supported.
 
 ## Caveats
 


### PR DESCRIPTION
## Summary

Updates the plugin to fully support the new clang-tools-static-binaries release [2026.06.05-5a535621](https://github.com/cpp-linter/clang-tools-static-binaries/releases/tag/2026.06.05-5a535621).

## What changed

The plugin dynamically discovers versions from the latest GitHub release, so no code changes were needed in `lib/utils.bash` or `bin/*`. The new release follows the same asset naming convention.

Two minor updates:

- **README.md**: Supported clang versions updated from `12–22` to `11–22` (version 11 is included in the release)
- **build.yml**: Added version `11` to the CI test matrix

## Verification

```bash
$ source lib/utils.bash && list_all_versions clang-format | sort_versions | xargs echo
11 12 13 14 15 16 17 18 19 20 21 22
```