### PR TITLE
docs: add back-navigation link to cpp-linter hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [clang-tools](https://github.com/cpp-linter/asdf-clang-tools) plugin for the [asdf version manager](https://asdf-vm.com).
 
-> 🏠 [← Back to cpp-linter hub](https://cpp-linter.github.io/)
+> [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 [clang-tools](https://github.com/cpp-linter/asdf-clang-tools) plugin for the [asdf version manager](https://asdf-vm.com).
 
+> 🏠 [← Back to cpp-linter hub](https://cpp-linter.github.io/)
+
 </div>
 
 # Overview


### PR DESCRIPTION
Adds `← Back to cpp-linter hub` link near the top of the README for easier cross-project navigation.