### PR TITLE
chore: optimize CI speed with caching, rate limiting, and reduced PR matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Determine which version matrix to use:
+  #   PRs:     quick check (oldest + newest)
+  #   main:    full release testing
+  compute-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.set-versions.outputs.versions }}
+    steps:
+      - id: set-versions
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo 'versions=["11","22"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'versions=["11","12","13","14","15","16","17","18","19","20","21","22"]' >> "$GITHUB_OUTPUT"
+          fi
+
   plugin_test:
     name: asdf plugin test
+    needs: compute-matrix
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      # Prevent flooding the GitHub API and hitting secondary rate limits
+      max-parallel: 8
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-15-intel]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel, windows-11-arm64]
         tool:
           - plugin: clang-format
             command: clang-format --version
@@ -33,7 +52,7 @@ jobs:
             command: clang-tidy --version
           - plugin: clang-apply-replacements
             command: clang-apply-replacements --version
-        version: ["11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22"]
+        version: ${{ fromJson(needs.compute-matrix.outputs.versions) }}
         exclude:
           # clang-apply-replacements-12_linux-amd64 is missing from upstream static-binaries
           - os: ubuntu-latest
@@ -46,11 +65,23 @@ jobs:
       - name: Install asdf
         uses: asdf-vm/actions/setup@v4
 
+      - name: Cache asdf installs
+        uses: actions/cache@v4
+        with:
+          path: ~/.asdf/installs
+          key: asdf-clang-tools-${{ matrix.os }}-${{ matrix.tool.plugin }}-${{ matrix.version }}-v1
+          # Fall back to a broader key to reuse cached downloads for the same OS+tool
+          restore-keys: |
+            asdf-clang-tools-${{ matrix.os }}-${{ matrix.tool.plugin }}-${{ matrix.version }}-
+            asdf-clang-tools-${{ matrix.os }}-${{ matrix.tool.plugin }}-
+
       - name: Add plugin ${{ matrix.tool.plugin }}
+        shell: bash
         run: |
           asdf plugin add ${{ matrix.tool.plugin }} "$GITHUB_WORKSPACE"
 
       - name: Install and test ${{ matrix.tool.plugin }} ${{ matrix.version }} on ${{ matrix.os }}
+        shell: bash
         run: |
           asdf install ${{ matrix.tool.plugin }} ${{ matrix.version }}
           asdf set ${{ matrix.tool.plugin }} ${{ matrix.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,18 @@ jobs:
       - name: Install and test ${{ matrix.tool.plugin }} ${{ matrix.version }} on ${{ matrix.os }}
         shell: bash
         run: |
-          asdf install ${{ matrix.tool.plugin }} ${{ matrix.version }}
+          INSTALL_DIR="$HOME/.asdf/installs/${{ matrix.tool.plugin }}/${{ matrix.version }}"
+          # If the cached install is valid (binary exists and is executable), use it.
+          # Otherwise remove the broken stub so asdf does a fresh install.
+          if [ -x "$INSTALL_DIR/bin/${{ matrix.tool.plugin }}" ]; then
+            echo "Using valid cached install for ${{ matrix.tool.plugin }} ${{ matrix.version }}"
+          else
+            if [ -d "$INSTALL_DIR" ]; then
+              echo "Cached install is broken, removing for fresh install"
+              rm -rf "$INSTALL_DIR"
+            fi
+            asdf install ${{ matrix.tool.plugin }} ${{ matrix.version }}
+          fi
           asdf set ${{ matrix.tool.plugin }} ${{ matrix.version }}
           which ${{ matrix.tool.plugin }}
           ${{ matrix.tool.command }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Clang versions **11** through **22** are supported.
 - Pre-compiled binaries are provided for:
   - Linux: `amd64` (`x86_64`), `arm64` (`aarch64`)
   - macOS: `amd64` (Intel), `arm64` (Apple Silicon)
-  - Windows: `amd64` (`x86_64`)
+  - Windows: `amd64` (`x86_64`), `arm64`
 - Signed binaries are not provided for macOS. This plugin will offer to de-quarantine the binaries for you, but please make sure you understand the consequences.
 
 # Dependencies

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -11,6 +11,7 @@ PLUGIN_NAME="clang-tools"
 USE_KERNEL=
 USE_ARCH=
 USE_PLATFORM=
+USE_EXE_SUFFIX=
 YES_REGEX='^[Yy](E|e)?(S|s)?$'
 
 fail() {
@@ -121,6 +122,18 @@ validate_platform() {
       esac
     fi
     ;;
+  MINGW* | MSYS* | CYGWIN*)
+    USE_KERNEL=windows
+    USE_EXE_SUFFIX=.exe
+    case $arch in
+    x86_64)
+      USE_ARCH=amd64
+      ;;
+    arm64 | aarch64)
+      USE_ARCH=arm64
+      ;;
+    esac
+    ;;
   esac
 
   if [ -z "${USE_KERNEL}" ] || [ -z "${USE_ARCH}" ]; then
@@ -158,7 +171,7 @@ download_release() {
 
   # TODO: split output without piping to awk
   url=$(fetch_all_assets |
-    grep "^${toolname}-${version}_${USE_PLATFORM}\s" |
+    grep "^${toolname}-${version}_${USE_PLATFORM}${USE_EXE_SUFFIX}\s" |
     awk '{print $2}')
 
   (
@@ -214,7 +227,7 @@ install_version() {
     cp -r "$ASDF_DOWNLOAD_PATH"/* "$asset_path"
 
     # TODO: detect this instead of hard-coding in case the format changes?
-    full_tool_cmd=${toolname}-${version}_${USE_PLATFORM}
+    full_tool_cmd=${toolname}-${version}_${USE_PLATFORM}${USE_EXE_SUFFIX}
     tool_cmd="$(echo "$toolname" | cut -d' ' -f1)"
 
     chmod +x "${asset_path}/${full_tool_cmd}"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -46,6 +46,13 @@ sort_versions() {
 }
 
 fetch_all_assets() {
+  # Reuse cached result to avoid redundant API calls within the same job
+  local cache_file="${TMPDIR:-/tmp}/asdf-clang-tools-assets-$$"
+  if [ -f "$cache_file" ]; then
+    cat "$cache_file"
+    return 0
+  fi
+
   # Build API-specific curl options without -f so we can read the error body
   local api_curl_opts=(-sSL)
   if [ -n "${GITHUB_TOKEN:-}" ]; then
@@ -59,7 +66,7 @@ fetch_all_assets() {
       "https://api.github.com/repos/${GH_REPO}/releases")
 
     if echo "$response" | jq -e 'type == "array"' >/dev/null 2>&1; then
-      echo "$response" | jq -r '.[0].assets[] | "\(.name) \(.browser_download_url)"'
+      echo "$response" | jq -r '.[0].assets[] | "\(.name) \(.browser_download_url)"' | tee "$cache_file"
       return 0
     fi
 


### PR DESCRIPTION
## Problem

The `build.yml` workflow creates **239 jobs** (5 OS × 4 tools × 12 versions), each hitting the GitHub API twice, downloading huge clang binaries with no caching, and flooding the API with no parallelism limit.

## Changes

### CI speed optimizations

1. **Reduced PR matrix (biggest impact)**
   - **PRs** now test only oldest + newest versions (`11`, `22`) → ~40 jobs
   - **Push to main** still tests all 12 versions → full coverage on merge
   - Uses a `compute-matrix` job with dynamic output

2. **Max parallelism** (`max-parallel: 8`)
   Prevents flooding the GitHub API with 239 simultaneous requests, avoiding secondary rate limits and the 15s→30s→45s backoff retries in `fetch_all_assets()`.

3. **Caching** (`actions/cache@v4`)
   Caches `~/.asdf/installs` per OS+tool+version, so clang binaries are only downloaded once. Subsequent runs hit the cache.

4. **API response caching in utils.bash**
   `fetch_all_assets()` was called twice per job (once from `list-all`, once from `download`). Now caches the response to a temp file within the job to halve API calls.

### ARM support (incorporates PR #40)

5. **Windows ARM64 + Linux ARM64 platform support**
   - Added `MINGW*/MSYS*/CYGWIN*` platform detection with `.exe` suffix
   - Added `arm64` arch support for Windows
   - Added `ubuntu-24.04-arm` and `windows-11-arm64` runners to CI matrix
   - Updated README to reflect Windows arm64 binary availability
   - Explicitly set `shell: bash` on Windows steps